### PR TITLE
Fixes #10 support Hamcrest's matcher

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,12 @@
       <version>6.5.2</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <version>1.3</version>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/src/main/java/net/jodah/concurrentunit/ConcurrentTestCase.java
+++ b/src/main/java/net/jodah/concurrentunit/ConcurrentTestCase.java
@@ -3,6 +3,8 @@ package net.jodah.concurrentunit;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.hamcrest.Matcher;
+
 /**
  * Convenience support class, wrapping a {@link Waiter}.
  * 
@@ -44,6 +46,13 @@ public abstract class ConcurrentTestCase {
    */
   public void threadAssertTrue(boolean b) {
     waiter.assertTrue(b);
+  }
+
+  /**
+   * @see Waiter#assertThat(Object, Matcher)
+   */
+  public <T> void threadAssertThat(T actual, Matcher<? super T> matcher) {
+    waiter.assertThat(actual, matcher);
   }
 
   /**

--- a/src/main/java/net/jodah/concurrentunit/Waiter.java
+++ b/src/main/java/net/jodah/concurrentunit/Waiter.java
@@ -6,6 +6,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import net.jodah.concurrentunit.internal.ReentrantCircuit;
 
+import org.hamcrest.Matcher;
+import org.hamcrest.MatcherAssert;
+
 /**
  * Waits on a test, carrying out assertions, until being resumed.
  * 
@@ -75,6 +78,19 @@ public class Waiter {
   public void assertTrue(boolean condition) {
     if (!condition)
       fail("expected true");
+  }
+
+  /**
+   * Asserts that {@code actual} satisfies the condition specified by {@code matcher}.
+   * 
+   * @throws AssertionError when the assertion fails
+   */
+  public <T> void assertThat(T actual, Matcher<? super T> matcher) {
+    try {
+      MatcherAssert.assertThat(actual, matcher);
+    } catch (AssertionError e) {
+      fail(e);
+    }
   }
 
   /**


### PR DESCRIPTION
It seems there are no tests for assertion itself like one verifying `assertEquals` in `WaiterTest` so I didn't add a test for `assertThat`.

Please let me know that if it has some issues. 